### PR TITLE
remove http bytes metrics

### DIFF
--- a/prometheus.go
+++ b/prometheus.go
@@ -10,20 +10,6 @@ var (
 		},
 		[]string{"code", "handler", "method"},
 	)
-	httpRequestSizeBytes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "http_request_size_bytes",
-			Help: "The HTTP request sizes in bytes.",
-		},
-		[]string{"code", "handler", "method"},
-	)
-	httpResponseSizeBytes = prometheus.NewHistogramVec(
-		prometheus.HistogramOpts{
-			Name: "http_response_size_bytes",
-			Help: "The HTTP response sizes in bytes.",
-		},
-		[]string{"code", "handler", "method"},
-	)
 	httpRequestsTotal = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Name: "http_requests_total",
@@ -34,28 +20,6 @@ var (
 )
 
 func init() {
-	// # HELP prometheus_build_info A metric with a constant '1' value labeled by version, revision, branch, and goversion from which prometheus was built.
-	// # TYPE prometheus_build_info gauge
-	// prometheus_build_info{branch="master",goversion="go1.7.5",revision="bd1182d29f462c39544f94cc822830e1c64cf55b",version="1.5.2"} 1
-
-	// # HELP prometheus_config_last_reload_success_timestamp_seconds Timestamp of the last successful configuration reload.
-	// # TYPE prometheus_config_last_reload_success_timestamp_seconds gauge
-	// prometheus_config_last_reload_success_timestamp_seconds 1.487454336e+09
-
-	// # HELP prometheus_config_last_reload_successful Whether the last configuration reload attempt was successful.
-	// # TYPE prometheus_config_last_reload_successful gauge
-	// prometheus_config_last_reload_successful 1
-
-	// # HELP prometheus_engine_queries The current number of queries being executed or waiting.
-	// # TYPE prometheus_engine_queries gauge
-	// prometheus_engine_queries 0
-
-	// # HELP prometheus_local_storage_checkpoint_last_duration_seconds The duration in seconds it took to last checkpoint open chunks and chunks yet to be persisted.
-	// # TYPE prometheus_local_storage_checkpoint_last_duration_seconds gauge
-	// prometheus_local_storage_checkpoint_last_duration_seconds 0.07150000000000001
-
 	prometheus.MustRegister(httpRequestDurationCounter)
-	prometheus.MustRegister(httpRequestSizeBytes)
-	prometheus.MustRegister(httpResponseSizeBytes)
 	prometheus.MustRegister(httpRequestsTotal)
 }


### PR DESCRIPTION
- remove http_request_size_bytes and http_response_size_bytes metrics
- request size used r.ContentLength which could be -1 for a multipart form
- histogram used default buckets which are geared toward request
  latency, not request/response bytes.
- storing these metrics is left to the importing package